### PR TITLE
Add badges to readme and don't run drone on pull requests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,8 @@ build:
     commands:
       - make testdeps test
     when:
-      event: [push, pull_request]
+      branch: master
+      event: push
   deploy:
     image: mediafactory/video-transcoding-api
     environment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ go:
   - tip
 services:
   - redis-server
+matrix:
+  allow_failures:
+    - go: tip

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 # Video Transcoding API
 
+[![Build Status](https://travis-ci.org/NYTimes/video-transcoding-api.svg?branch=master)](https://travis-ci.org/NYTimes/video-transcoding-api)
+[![codecov](https://codecov.io/gh/NYTimes/video-transcoding-api/branch/master/graph/badge.svg)](https://codecov.io/gh/NYTimes/video-transcoding-api)
+
 The Video Transcoding API provides an agnostic API to transcode media assets
 across different cloud services. Currently, it supports the following
 providers:


### PR DESCRIPTION
We want drone to run tests and deploy master, but travis will handle
pull requests.