### PR TITLE
drone: send notifications only for tags and pushes on master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,3 +69,12 @@ notify:
     webhook_url: $$SLACK_WEBHOOK_URL
     username: $$SLACK_USERNAME
     channel: $$SLACK_CHANNEL
+    when:
+      branch: master
+      event: push
+  slack:
+    webhook_url: $$SLACK_WEBHOOK_URL
+    username: $$SLACK_USERNAME
+    channel: $$SLACK_CHANNEL
+    when:
+      event: tag


### PR DESCRIPTION
I'd love to have an or operation for branches and tags (I want
notifications when we're tagging or when we're pushing on master, but
it looks like we can't do that).