### PR TITLE
db/redis: add tests for FieldMap()

### DIFF
--- a/db/redis/storage/redis_test.go
+++ b/db/redis/storage/redis_test.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/NYTimes/video-transcoding-api/db"
 )
 
 func TestRedisClientRedisDefaultOptions(t *testing.T) {
@@ -242,20 +240,20 @@ func TestFieldMap(t *testing.T) {
 		expected    map[string]string
 	}{
 		{
-			"db.Job",
-			db.Job{
+			"Job",
+			Job{
 				ID:            "job1",
 				ProviderJobID: "123abc",
 				SourceMedia:   "http://nyt.net/source_here.mp4",
 				ProviderName:  "encoding.com",
-				StreamingParams: db.StreamingParams{
+				StreamingParams: StreamingParams{
 					SegmentDuration:  10,
 					Protocol:         "hls",
 					PlaylistFileName: "hls/playlist.m3u8",
 				},
-				Outputs: []db.TranscodeOutput{
-					{Preset: db.PresetMap{Name: "preset-1"}, FileName: "output1.m3u8"},
-					{Preset: db.PresetMap{Name: "preset-2"}, FileName: "output2.m3u8"},
+				Outputs: []TranscodeOutput{
+					{Preset: PresetMap{Name: "preset-1"}, FileName: "output1.m3u8"},
+					{Preset: PresetMap{Name: "preset-2"}, FileName: "output2.m3u8"},
 				},
 			},
 			map[string]string{
@@ -270,15 +268,15 @@ func TestFieldMap(t *testing.T) {
 			},
 		},
 		{
-			"db.LocalPreset",
-			db.LocalPreset{
+			"LocalPreset",
+			LocalPreset{
 				Name: "this-is-a-localpreset",
-				Preset: db.Preset{
+				Preset: Preset{
 					Name:        "test",
 					Description: "test preset",
 					Container:   "mp4",
 					RateControl: "VBR",
-					Video: db.VideoPreset{
+					Video: VideoPreset{
 						Profile:       "main",
 						ProfileLevel:  "3.1",
 						Width:         "640",
@@ -289,7 +287,7 @@ func TestFieldMap(t *testing.T) {
 						GopMode:       "fixed",
 						InterlaceMode: "progressive",
 					},
-					Audio: db.AudioPreset{
+					Audio: AudioPreset{
 						Codec:   "aac",
 						Bitrate: "64000",
 					},

--- a/db/redis/storage/redis_test.go
+++ b/db/redis/storage/redis_test.go
@@ -236,37 +236,93 @@ func TestFieldMap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	job := db.Job{
-		ID:            "job1",
-		ProviderJobID: "123abc",
-		SourceMedia:   "http://nyt.net/source_here.mp4",
-		ProviderName:  "encoding.com",
-		StreamingParams: db.StreamingParams{
-			SegmentDuration:  10,
-			Protocol:         "hls",
-			PlaylistFileName: "hls/playlist.m3u8",
+	var tests = []struct {
+		description string
+		hash        interface{}
+		expected    map[string]string
+	}{
+		{
+			"db.Job",
+			db.Job{
+				ID:            "job1",
+				ProviderJobID: "123abc",
+				SourceMedia:   "http://nyt.net/source_here.mp4",
+				ProviderName:  "encoding.com",
+				StreamingParams: db.StreamingParams{
+					SegmentDuration:  10,
+					Protocol:         "hls",
+					PlaylistFileName: "hls/playlist.m3u8",
+				},
+				Outputs: []db.TranscodeOutput{
+					{Preset: db.PresetMap{Name: "preset-1"}, FileName: "output1.m3u8"},
+					{Preset: db.PresetMap{Name: "preset-2"}, FileName: "output2.m3u8"},
+				},
+			},
+			map[string]string{
+				"source":                           "http://nyt.net/source_here.mp4",
+				"jobID":                            "job1",
+				"providerName":                     "encoding.com",
+				"providerJobID":                    "123abc",
+				"streamingparams_segmentDuration":  "10",
+				"streamingparams_protocol":         "hls",
+				"streamingparams_playlistFileName": "hls/playlist.m3u8",
+				"creationTime":                     "0001-01-01T00:00:00Z",
+			},
 		},
-		Outputs: []db.TranscodeOutput{
-			{Preset: db.PresetMap{Name: "preset-1"}, FileName: "output1.m3u8"},
-			{Preset: db.PresetMap{Name: "preset-2"}, FileName: "output2.m3u8"},
+		{
+			"db.LocalPreset",
+			db.LocalPreset{
+				Name: "this-is-a-localpreset",
+				Preset: db.Preset{
+					Name:        "test",
+					Description: "test preset",
+					Container:   "mp4",
+					RateControl: "VBR",
+					Video: db.VideoPreset{
+						Profile:       "main",
+						ProfileLevel:  "3.1",
+						Width:         "640",
+						Height:        "360",
+						Codec:         "h264",
+						Bitrate:       "1000",
+						GopSize:       "90",
+						GopMode:       "fixed",
+						InterlaceMode: "progressive",
+					},
+					Audio: db.AudioPreset{
+						Codec:   "aac",
+						Bitrate: "64000",
+					},
+				},
+			},
+			map[string]string{
+				"preset_name":                "test",
+				"preset_description":         "test preset",
+				"preset_container":           "mp4",
+				"preset_ratecontrol":         "VBR",
+				"preset_video_profilelevel":  "3.1",
+				"preset_video_profile":       "main",
+				"preset_video_gopmode":       "fixed",
+				"preset_video_bitrate":       "1000",
+				"preset_video_interlacemode": "progressive",
+				"preset_video_codec":         "h264",
+				"preset_video_gopsize":       "90",
+				"preset_video_height":        "360",
+				"preset_video_width":         "640",
+				"preset_audio_bitrate":       "64000",
+				"preset_audio_codec":         "aac",
+			},
 		},
 	}
-	expected := map[string]string{
-		"source":                           "http://nyt.net/source_here.mp4",
-		"jobID":                            "job1",
-		"providerName":                     "encoding.com",
-		"providerJobID":                    "123abc",
-		"streamingparams_segmentDuration":  "10",
-		"streamingparams_protocol":         "hls",
-		"streamingparams_playlistFileName": "hls/playlist.m3u8",
-		"creationTime":                     "0001-01-01T00:00:00Z",
-	}
-	result, err := storage.FieldMap(job)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Wrong FieldMap. Want %#v. Got %#v.", result, expected)
+
+	for _, test := range tests {
+		result, err := storage.FieldMap(test.hash)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("Wrong FieldMap: %s: Want %#v. Got %#v.", test.description, result, test.expected)
+		}
 	}
 }
 

--- a/db/redis/storage/stub_test.go
+++ b/db/redis/storage/stub_test.go
@@ -32,3 +32,63 @@ type InvalidStruct struct {
 type InvalidInnerStruct struct {
 	Data map[string]int `redis-hash:"data,expand"`
 }
+
+type Job struct {
+	ID              string            `redis-hash:"jobID"`
+	ProviderName    string            `redis-hash:"providerName"`
+	ProviderJobID   string            `redis-hash:"providerJobID"`
+	StreamingParams StreamingParams   `redis-hash:"streamingparams,expand"`
+	CreationTime    time.Time         `redis-hash:"creationTime"`
+	SourceMedia     string            `redis-hash:"source"`
+	Outputs         []TranscodeOutput `redis-hash:"-"`
+}
+
+type TranscodeOutput struct {
+	Preset   PresetMap `redis-hash:"presetmap,expand"`
+	FileName string    `redis-hash:"filename"`
+}
+
+type PresetMap struct {
+	Name string `redis-hash:"presetmap_name"`
+}
+
+type OutputOptions struct {
+	Extension string `redis-hash:"extension"`
+}
+
+type StreamingParams struct {
+	SegmentDuration  uint   `redis-hash:"segmentDuration"`
+	Protocol         string `redis-hash:"protocol"`
+	PlaylistFileName string `redis-hash:"playlistFileName"`
+}
+
+type LocalPreset struct {
+	Name   string `redis-hash:"-"`
+	Preset Preset `redis-hash:"preset,expand"`
+}
+
+type Preset struct {
+	Name        string      `redis-hash:"name"`
+	Description string      `redis-hash:"description,omitempty"`
+	Container   string      `redis-hash:"container,omitempty"`
+	RateControl string      `redis-hash:"ratecontrol,omitempty"`
+	Video       VideoPreset `redis-hash:"video,expand"`
+	Audio       AudioPreset `redis-hash:"audio,expand"`
+}
+
+type VideoPreset struct {
+	Profile       string `redis-hash:"profile,omitempty"`
+	ProfileLevel  string `redis-hash:"profilelevel,omitempty"`
+	Width         string `redis-hash:"width,omitempty"`
+	Height        string `redis-hash:"height,omitempty"`
+	Codec         string `redis-hash:"codec,omitempty"`
+	Bitrate       string `redis-hash:"bitrate,omitempty"`
+	GopSize       string `redis-hash:"gopsize,omitempty"`
+	GopMode       string `redis-hash:"gopmode,omitempty"`
+	InterlaceMode string `redis-hash:"interlacemode,omitempty"`
+}
+
+type AudioPreset struct {
+	Codec   string `redis-hash:"codec,omitempty"`
+	Bitrate string `redis-hash:"bitrate,omitempty"`
+}

--- a/db/redis/storage/stub_test.go
+++ b/db/redis/storage/stub_test.go
@@ -52,10 +52,6 @@ type PresetMap struct {
 	Name string `redis-hash:"presetmap_name"`
 }
 
-type OutputOptions struct {
-	Extension string `redis-hash:"extension"`
-}
-
 type StreamingParams struct {
 	SegmentDuration  uint   `redis-hash:"segmentDuration"`
 	Protocol         string `redis-hash:"protocol"`


### PR DESCRIPTION
Initially I started this branch to solve the issue #139 so I wrote tests to instrument the modifications. The code to support flatten arrays of structs into hashes sounds like a workaround and I decided to give up. 

Talking with @fsouza we'll probably abort this approach and save the json as a string.