### PR TITLE
Populate status message

### DIFF
--- a/provider/elastictranscoder/aws.go
+++ b/provider/elastictranscoder/aws.go
@@ -285,9 +285,18 @@ func (p *awsProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
 			Width:    aws.Int64Value(resp.Job.Input.DetectedProperties.Width),
 		}
 	}
+	statusMessage := ""
+	if len(resp.Job.Outputs) > 0 {
+		statusMessage = aws.StringValue(resp.Job.Outputs[0].StatusDetail)
+		if strings.Contains(statusMessage, ":") {
+			errorMessage := strings.Split(statusMessage, ":")[1]
+			statusMessage = strings.Trim(errorMessage, " ")
+		}
+	}
 	return &provider.JobStatus{
 		ProviderJobID:  aws.StringValue(resp.Job.Id),
 		Status:         p.statusMap(aws.StringValue(resp.Job.Status)),
+		StatusMessage:  statusMessage,
 		Progress:       completedJobs / float64(totalJobs) * 100,
 		ProviderStatus: map[string]interface{}{"outputs": outputs},
 		SourceInfo:     sourceInfo,

--- a/provider/elastictranscoder/aws_test.go
+++ b/provider/elastictranscoder/aws_test.go
@@ -658,6 +658,7 @@ func TestAWSJobStatus(t *testing.T) {
 	expectedJobStatus := provider.JobStatus{
 		ProviderJobID: jobStatus.ProviderJobID,
 		Status:        provider.StatusFinished,
+		StatusMessage: "it's finished!",
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
 			"outputs": map[string]interface{}{
@@ -752,6 +753,7 @@ func TestAWSJobStatusNoDetectedProperties(t *testing.T) {
 	expectedJobStatus := provider.JobStatus{
 		ProviderJobID: jobStatus.ProviderJobID,
 		Status:        provider.StatusFinished,
+		StatusMessage: "it's finished!",
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
 			"outputs": map[string]interface{}{

--- a/provider/elementalconductor/elementalconductor.go
+++ b/provider/elementalconductor/elementalconductor.go
@@ -127,11 +127,16 @@ func (p *elementalConductorProvider) JobStatus(job *db.Job) (*provider.JobStatus
 	if resp.ContentDuration != nil {
 		duration = time.Duration(resp.ContentDuration.InputDuration) * time.Second
 	}
+	statusMessage := ""
+	if len(resp.ErrorMessages) > 0 {
+		statusMessage = resp.ErrorMessages[0].Message
+	}
 	return &provider.JobStatus{
 		ProviderName:   Name,
 		ProviderJobID:  job.ProviderJobID,
 		Progress:       float64(resp.PercentComplete),
 		Status:         p.statusMap(resp.Status),
+		StatusMessage:  statusMessage,
 		ProviderStatus: providerStatus,
 		SourceInfo: provider.SourceInfo{
 			Duration:   duration,

--- a/provider/encodingcom/encodingcom.go
+++ b/provider/encodingcom/encodingcom.go
@@ -227,10 +227,16 @@ func (e *encodingComProvider) JobStatus(job *db.Job) (*provider.JobStatus, error
 			return nil, err
 		}
 	}
+	formatStatus := e.getFormatStatus(resp)
+	statusMessage := ""
+	if len(formatStatus) > 0 {
+		statusMessage = formatStatus[0]
+	}
 	return &provider.JobStatus{
 		ProviderJobID: job.ProviderJobID,
 		ProviderName:  "encoding.com",
 		Status:        status,
+		StatusMessage: statusMessage,
 		Progress:      resp[0].Progress,
 		ProviderStatus: map[string]interface{}{
 			"sourcefile":   resp[0].SourceFile,
@@ -238,7 +244,7 @@ func (e *encodingComProvider) JobStatus(job *db.Job) (*provider.JobStatus, error
 			"created":      resp[0].CreateDate,
 			"started":      resp[0].StartDate,
 			"finished":     resp[0].FinishDate,
-			"formatStatus": e.getFormatStatus(resp),
+			"formatStatus": formatStatus,
 		},
 		Output: provider.JobOutput{
 			Destination: e.getOutputDestination(job),
@@ -280,7 +286,11 @@ func (e *encodingComProvider) getFormatStatus(status []encodingcom.StatusRespons
 	formatStatusList := []string{}
 	formats := status[0].Formats
 	for _, formatStatus := range formats {
-		formatStatusList = append(formatStatusList, formatStatus.Status)
+		statusMessage := formatStatus.Status
+		if statusMessage == "Error" {
+			statusMessage = statusMessage + ": " + formatStatus.Description
+		}
+		formatStatusList = append(formatStatusList, statusMessage)
 	}
 	return formatStatusList
 }

--- a/provider/encodingcom/encodingcom_server_test.go
+++ b/provider/encodingcom/encodingcom_server_test.go
@@ -41,12 +41,13 @@ type fakePreset struct {
 }
 
 type fakeMedia struct {
-	ID       string
-	Request  request
-	Created  time.Time
-	Started  time.Time
-	Finished time.Time
-	Status   string
+	ID          string
+	Request     request
+	Created     time.Time
+	Started     time.Time
+	Finished    time.Time
+	Status      string
+	Description string
 }
 
 // encodingComFakeServer is a fake version of the Encoding.com API.
@@ -189,6 +190,8 @@ func (s *encodingComFakeServer) getStatus(w http.ResponseWriter, req request) {
 			"finished":   media.Finished.Format(encodingComDateFormat),
 			"output":     hlsOutput,
 			"format": map[string]interface{}{
+				"status":      status,
+				"description": media.Description,
 				"destination": []string{
 					"https://mybucket.s3.amazonaws.com/dir/job-123/some_hls_preset/video-0.m3u8",
 					"https://mybucket.s3.amazonaws.com/dir/job-123/video.m3u8",

--- a/provider/encodingcom/encodingcom_test.go
+++ b/provider/encodingcom/encodingcom_test.go
@@ -512,7 +512,7 @@ func TestJobStatus(t *testing.T) {
 		ProviderJobID: "mymedia",
 		ProviderName:  "encoding.com",
 		Status:        provider.StatusFinished,
-		StatusMessage: "",
+		StatusMessage: "Finished",
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
 			"sourcefile":   "http://some.source.file",
@@ -520,7 +520,7 @@ func TestJobStatus(t *testing.T) {
 			"created":      media.Created,
 			"started":      media.Started,
 			"finished":     media.Finished,
-			"formatStatus": []string{""},
+			"formatStatus": []string{"Finished"},
 		},
 		SourceInfo: provider.SourceInfo{
 			Duration:   183e9,
@@ -592,7 +592,7 @@ func TestJobStatusNotFinished(t *testing.T) {
 		ProviderJobID: "mymedia",
 		ProviderName:  "encoding.com",
 		Status:        provider.StatusStarted,
-		StatusMessage: "",
+		StatusMessage: "Saving",
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
 			"sourcefile":   "http://some.source.file",
@@ -600,7 +600,7 @@ func TestJobStatusNotFinished(t *testing.T) {
 			"created":      media.Created,
 			"started":      media.Started,
 			"finished":     media.Finished,
-			"formatStatus": []string{""},
+			"formatStatus": []string{"Saving"},
 		},
 		Output: provider.JobOutput{
 			Destination: "s3://mybucket/dir/job-123/",
@@ -682,30 +682,58 @@ func TestJobStatusInvalidSourceInfo(t *testing.T) {
 		Finished: now.Add(time.Hour),
 	}
 	server.medias["media3"] = &media3
+	media4 := fakeMedia{
+		ID: "media4",
+		Request: request{
+			Format: []encodingcom.Format{
+				{
+					VideoCodec: "VP9",
+					Output:     []string{"webm"},
+				},
+			},
+		},
+		Status:      "Error",
+		Description: "Something",
+		Created:     now,
+		Started:     now.Add(time.Minute),
+		Finished:    now.Add(time.Hour),
+	}
+	server.medias["media4"] = &media4
 	var tests = []struct {
-		testCase string
-		mediaID  string
-		errMsg   string
+		testCase                   string
+		mediaID                    string
+		errMsg                     string
+		resultingStatusShouldBeNil bool
 	}{
 		{
 			"invalid media ID",
 			"something",
 			`Error returned by the Encoding.com API: {"Errors":["media not found"]}`,
+			true,
 		},
 		{
 			"invalid height",
 			"media1",
 			`invalid size returned by the Encoding.com API ("1920x1080x900"): strconv.ParseInt: parsing "1080x900": invalid syntax`,
+			true,
 		},
 		{
 			"invalid width",
 			"media2",
 			`invalid size returned by the Encoding.com API ("πx1080"): strconv.ParseInt: parsing "π": invalid syntax`,
+			true,
 		},
 		{
 			"invalid size",
 			"media3",
 			`invalid size returned by the Encoding.com API: "π"`,
+			true,
+		},
+		{
+			"error status",
+			"media4",
+			`Error: Something`,
+			false,
 		},
 	}
 	client, err := encodingcom.NewClient(server.URL, "myuser", "secret")
@@ -720,15 +748,18 @@ func TestJobStatusInvalidSourceInfo(t *testing.T) {
 	}
 	for _, test := range tests {
 		jobStatus, err := prov.JobStatus(&db.Job{ProviderJobID: test.mediaID})
-		if jobStatus != nil {
+		if test.resultingStatusShouldBeNil && jobStatus != nil {
 			t.Errorf("%s: got unexpected non-nil status: %#v", test.testCase, jobStatus)
 		}
-		if err == nil {
+		if test.resultingStatusShouldBeNil && err == nil {
 			t.Errorf("%s: got unexpected <nil> error", test.testCase)
 			continue
 		}
-		if err.Error() != test.errMsg {
+		if test.resultingStatusShouldBeNil && err.Error() != test.errMsg {
 			t.Errorf("%s: wrong error message\nwant %q\ngot  %q", test.testCase, test.errMsg, err.Error())
+		}
+		if !test.resultingStatusShouldBeNil && test.errMsg != jobStatus.StatusMessage {
+			t.Errorf("%s: wrong error message\nwant %q\ngot  %q", test.testCase, test.errMsg, jobStatus.StatusMessage)
 		}
 	}
 }

--- a/provider/zencoder/zencoder.go
+++ b/provider/zencoder/zencoder.go
@@ -274,10 +274,15 @@ func (z *zencoderProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
 		return nil, fmt.Errorf("error getting job progress: %s", err)
 	}
 	inputMediaFile := jobDetails.Job.InputMediaFile
+	statusMessage := ""
+	if inputMediaFile.ErrorMessage != nil {
+		statusMessage = *inputMediaFile.ErrorMessage
+	}
 	return &provider.JobStatus{
 		ProviderName:  Name,
 		ProviderJobID: job.ProviderJobID,
 		Status:        z.statusMap(progress.State),
+		StatusMessage: statusMessage,
 		Progress:      progress.JobProgress,
 		Output:        jobOutputs,
 		SourceInfo: provider.SourceInfo{

--- a/provider/zencoder/zencoder_fake_test.go
+++ b/provider/zencoder/zencoder_fake_test.go
@@ -23,6 +23,44 @@ func (z *FakeZencoder) GetJobProgress(id int64) (*zencoder.JobProgress, error) {
 }
 
 func (z *FakeZencoder) GetJobDetails(id int64) (*zencoder.JobDetails, error) {
+	if id == 11111 {
+		errorMessage := "Some error happened."
+		return &zencoder.JobDetails{
+			Job: &zencoder.Job{
+				InputMediaFile: &zencoder.MediaFile{
+					Url:          "http://nyt.net/input.mov",
+					Format:       "mov",
+					VideoCodec:   "ProRes422",
+					Width:        1920,
+					Height:       1080,
+					DurationInMs: 10000,
+					ErrorMessage: &errorMessage,
+				},
+				CreatedAt:   "2016-11-05T05:02:57Z",
+				FinishedAt:  "2016-11-05T05:02:57Z",
+				UpdatedAt:   "2016-11-05T05:02:57Z",
+				SubmittedAt: "2016-11-05T05:02:57Z",
+				OutputMediaFiles: []*zencoder.MediaFile{
+					{
+						Url:          "https://mybucket.s3.amazonaws.com/destination-dir/output1.mp4",
+						Format:       "mp4",
+						VideoCodec:   "h264",
+						Width:        1920,
+						Height:       1080,
+						DurationInMs: 10000,
+					},
+					{
+						Url:          "https://mybucket.s3.amazonaws.com/destination-dir/output2.webm",
+						Format:       "webm",
+						VideoCodec:   "vp8",
+						Width:        1080,
+						Height:       720,
+						DurationInMs: 10000,
+					},
+				},
+			},
+		}, nil
+	}
 	return &zencoder.JobDetails{
 		Job: &zencoder.Job{
 			InputMediaFile: &zencoder.MediaFile{

--- a/provider/zencoder/zencoder_test.go
+++ b/provider/zencoder/zencoder_test.go
@@ -860,62 +860,80 @@ func TestZencoderJobStatus(t *testing.T) {
 		client: fakeZencoder,
 		db:     dbRepo,
 	}
-	jobStatus, err := prov.JobStatus(&db.Job{
-		ProviderJobID: "1234567890",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	resultJSON, err := json.Marshal(jobStatus)
-	if err != nil {
-		t.Fatal(err)
-	}
-	result := make(map[string]interface{})
-	err = json.Unmarshal(resultJSON, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := map[string]interface{}{
-		"providerName":  "zencoder",
-		"providerJobId": "1234567890",
-		"status":        "started",
-		"progress":      float64(10),
-		"sourceInfo": map[string]interface{}{
-			"duration":   float64(10000000),
-			"height":     float64(1080),
-			"width":      float64(1920),
-			"videoCodec": "ProRes422",
+	var tests = []struct {
+		jobID         string
+		expectedError string
+	}{
+		{
+			"12345",
+			"",
 		},
-		"providerStatus": map[string]interface{}{
-			"sourcefile": "http://nyt.net/input.mov",
-			"created":    "2016-11-05T05:02:57Z",
-			"finished":   "2016-11-05T05:02:57Z",
-			"updated":    "2016-11-05T05:02:57Z",
-			"started":    "2016-11-05T05:02:57Z",
+		{
+			"11111",
+			"Some error happened.",
 		},
-		"output": map[string]interface{}{
-			"destination": "/",
-			"files": []interface{}{
-				map[string]interface{}{
-					"path":       "s3://mybucket/destination-dir/output1.mp4",
-					"container":  "mp4",
-					"videoCodec": "h264",
-					"height":     float64(1080),
-					"width":      float64(1920),
-				},
-				map[string]interface{}{
-					"height":     float64(720),
-					"width":      float64(1080),
-					"path":       "s3://mybucket/destination-dir/output2.webm",
-					"container":  "webm",
-					"videoCodec": "vp8",
+	}
+	for _, test := range tests {
+		jobStatus, err := prov.JobStatus(&db.Job{
+			ProviderJobID: test.jobID,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		resultJSON, err := json.Marshal(jobStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := make(map[string]interface{})
+		err = json.Unmarshal(resultJSON, &result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := map[string]interface{}{
+			"providerName":  "zencoder",
+			"providerJobId": test.jobID,
+			"status":        "started",
+			"progress":      float64(10),
+			"sourceInfo": map[string]interface{}{
+				"duration":   float64(10000000),
+				"height":     float64(1080),
+				"width":      float64(1920),
+				"videoCodec": "ProRes422",
+			},
+			"providerStatus": map[string]interface{}{
+				"sourcefile": "http://nyt.net/input.mov",
+				"created":    "2016-11-05T05:02:57Z",
+				"finished":   "2016-11-05T05:02:57Z",
+				"updated":    "2016-11-05T05:02:57Z",
+				"started":    "2016-11-05T05:02:57Z",
+			},
+			"output": map[string]interface{}{
+				"destination": "/",
+				"files": []interface{}{
+					map[string]interface{}{
+						"path":       "s3://mybucket/destination-dir/output1.mp4",
+						"container":  "mp4",
+						"videoCodec": "h264",
+						"height":     float64(1080),
+						"width":      float64(1920),
+					},
+					map[string]interface{}{
+						"height":     float64(720),
+						"width":      float64(1080),
+						"path":       "s3://mybucket/destination-dir/output2.webm",
+						"container":  "webm",
+						"videoCodec": "vp8",
+					},
 				},
 			},
-		},
-	}
-	if !reflect.DeepEqual(result, expected) {
-		pretty.Fdiff(os.Stderr, expected, result)
-		t.Errorf("Wrong JobStatus returned. Want %#v. Got %#v.", expected, result)
+		}
+		if test.expectedError != "" {
+			expected["statusMessage"] = test.expectedError
+		}
+		if !reflect.DeepEqual(result, expected) {
+			pretty.Fdiff(os.Stderr, expected, result)
+			t.Errorf("Wrong JobStatus returned. Want %#v. Got %#v.", expected, result)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds logic for each provider implementation to populate the field `statusMessage` on job status, which will used during error conditions to store a more user friendly error message.