### PR TITLE
Revert "Populate status message" and re-apply it with minor fix.

### DIFF
--- a/provider/elastictranscoder/aws.go
+++ b/provider/elastictranscoder/aws.go
@@ -285,18 +285,9 @@ func (p *awsProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
 			Width:    aws.Int64Value(resp.Job.Input.DetectedProperties.Width),
 		}
 	}
-	statusMessage := ""
-	if len(resp.Job.Outputs) > 0 {
-		statusMessage = aws.StringValue(resp.Job.Outputs[0].StatusDetail)
-		if strings.Contains(statusMessage, ":") {
-			errorMessage := strings.Split(statusMessage, ":")[1]
-			statusMessage = strings.Trim(errorMessage, " ")
-		}
-	}
 	return &provider.JobStatus{
 		ProviderJobID:  aws.StringValue(resp.Job.Id),
 		Status:         p.statusMap(aws.StringValue(resp.Job.Status)),
-		StatusMessage:  statusMessage,
 		Progress:       completedJobs / float64(totalJobs) * 100,
 		ProviderStatus: map[string]interface{}{"outputs": outputs},
 		SourceInfo:     sourceInfo,

--- a/provider/elastictranscoder/aws.go
+++ b/provider/elastictranscoder/aws.go
@@ -285,9 +285,18 @@ func (p *awsProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
 			Width:    aws.Int64Value(resp.Job.Input.DetectedProperties.Width),
 		}
 	}
+	statusMessage := ""
+	if len(resp.Job.Outputs) > 0 {
+		statusMessage = aws.StringValue(resp.Job.Outputs[0].StatusDetail)
+		if strings.Contains(statusMessage, ":") {
+			errorMessage := strings.SplitN(statusMessage, ":", 2)[1]
+			statusMessage = strings.TrimSpace(errorMessage)
+		}
+	}
 	return &provider.JobStatus{
 		ProviderJobID:  aws.StringValue(resp.Job.Id),
 		Status:         p.statusMap(aws.StringValue(resp.Job.Status)),
+		StatusMessage:  statusMessage,
 		Progress:       completedJobs / float64(totalJobs) * 100,
 		ProviderStatus: map[string]interface{}{"outputs": outputs},
 		SourceInfo:     sourceInfo,

--- a/provider/elastictranscoder/aws_test.go
+++ b/provider/elastictranscoder/aws_test.go
@@ -658,6 +658,7 @@ func TestAWSJobStatus(t *testing.T) {
 	expectedJobStatus := provider.JobStatus{
 		ProviderJobID: jobStatus.ProviderJobID,
 		Status:        provider.StatusFinished,
+		StatusMessage: "it's finished!",
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
 			"outputs": map[string]interface{}{
@@ -752,6 +753,7 @@ func TestAWSJobStatusNoDetectedProperties(t *testing.T) {
 	expectedJobStatus := provider.JobStatus{
 		ProviderJobID: jobStatus.ProviderJobID,
 		Status:        provider.StatusFinished,
+		StatusMessage: "it's finished!",
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
 			"outputs": map[string]interface{}{

--- a/provider/elastictranscoder/aws_test.go
+++ b/provider/elastictranscoder/aws_test.go
@@ -658,7 +658,6 @@ func TestAWSJobStatus(t *testing.T) {
 	expectedJobStatus := provider.JobStatus{
 		ProviderJobID: jobStatus.ProviderJobID,
 		Status:        provider.StatusFinished,
-		StatusMessage: "it's finished!",
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
 			"outputs": map[string]interface{}{
@@ -753,7 +752,6 @@ func TestAWSJobStatusNoDetectedProperties(t *testing.T) {
 	expectedJobStatus := provider.JobStatus{
 		ProviderJobID: jobStatus.ProviderJobID,
 		Status:        provider.StatusFinished,
-		StatusMessage: "it's finished!",
 		Progress:      100,
 		ProviderStatus: map[string]interface{}{
 			"outputs": map[string]interface{}{

--- a/provider/elementalconductor/elementalconductor.go
+++ b/provider/elementalconductor/elementalconductor.go
@@ -127,16 +127,11 @@ func (p *elementalConductorProvider) JobStatus(job *db.Job) (*provider.JobStatus
 	if resp.ContentDuration != nil {
 		duration = time.Duration(resp.ContentDuration.InputDuration) * time.Second
 	}
-	statusMessage := ""
-	if len(resp.ErrorMessages) > 0 {
-		statusMessage = resp.ErrorMessages[0].Message
-	}
 	return &provider.JobStatus{
 		ProviderName:   Name,
 		ProviderJobID:  job.ProviderJobID,
 		Progress:       float64(resp.PercentComplete),
 		Status:         p.statusMap(resp.Status),
-		StatusMessage:  statusMessage,
 		ProviderStatus: providerStatus,
 		SourceInfo: provider.SourceInfo{
 			Duration:   duration,

--- a/provider/elementalconductor/elementalconductor_test.go
+++ b/provider/elementalconductor/elementalconductor_test.go
@@ -2,7 +2,6 @@ package elementalconductor
 
 import (
 	"encoding/xml"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -11,7 +10,6 @@ import (
 	"github.com/NYTimes/video-transcoding-api/config"
 	"github.com/NYTimes/video-transcoding-api/db"
 	"github.com/NYTimes/video-transcoding-api/provider"
-	"github.com/kr/pretty"
 )
 
 func TestFactoryIsRegistered(t *testing.T) {
@@ -736,11 +734,6 @@ func TestJobStatus(t *testing.T) {
 	client := newFakeElementalConductorClient(&elementalConductorConfig)
 	client.jobs["job-1"] = elementalconductor.Job{
 		Href: "whatever",
-		ErrorMessages: []elementalconductor.JobError{
-			{
-				Message: "This is some error.",
-			},
-		},
 		Input: elementalconductor.Input{
 			InputInfo: &elementalconductor.InputInfo{
 				Video: elementalconductor.VideoInputInfo{
@@ -865,7 +858,6 @@ func TestJobStatus(t *testing.T) {
 		ProviderJobID: "job-1",
 		Progress:      89.,
 		Status:        provider.StatusStarted,
-		StatusMessage: "This is some error.",
 		Output: provider.JobOutput{
 			Destination: "s3://destination/super-job-1",
 			Files: []provider.OutputFile{
@@ -898,15 +890,9 @@ func TestJobStatus(t *testing.T) {
 		ProviderStatus: map[string]interface{}{
 			"status":    "running",
 			"submitted": submitted,
-			"error_messages": []elementalconductor.JobError{
-				{
-					Message: "This is some error.",
-				},
-			},
 		},
 	}
 	if !reflect.DeepEqual(*jobStatus, expectedJobStatus) {
-		pretty.Fdiff(os.Stderr, expectedJobStatus, *jobStatus)
 		t.Errorf("wrong job stats\nwant %#v\ngot  %#v", expectedJobStatus, *jobStatus)
 	}
 }

--- a/provider/encodingcom/encodingcom.go
+++ b/provider/encodingcom/encodingcom.go
@@ -227,16 +227,10 @@ func (e *encodingComProvider) JobStatus(job *db.Job) (*provider.JobStatus, error
 			return nil, err
 		}
 	}
-	formatStatus := e.getFormatStatus(resp)
-	statusMessage := ""
-	if len(formatStatus) > 0 {
-		statusMessage = formatStatus[0]
-	}
 	return &provider.JobStatus{
 		ProviderJobID: job.ProviderJobID,
 		ProviderName:  "encoding.com",
 		Status:        status,
-		StatusMessage: statusMessage,
 		Progress:      resp[0].Progress,
 		ProviderStatus: map[string]interface{}{
 			"sourcefile":   resp[0].SourceFile,
@@ -244,7 +238,7 @@ func (e *encodingComProvider) JobStatus(job *db.Job) (*provider.JobStatus, error
 			"created":      resp[0].CreateDate,
 			"started":      resp[0].StartDate,
 			"finished":     resp[0].FinishDate,
-			"formatStatus": formatStatus,
+			"formatStatus": e.getFormatStatus(resp),
 		},
 		Output: provider.JobOutput{
 			Destination: e.getOutputDestination(job),
@@ -286,11 +280,7 @@ func (e *encodingComProvider) getFormatStatus(status []encodingcom.StatusRespons
 	formatStatusList := []string{}
 	formats := status[0].Formats
 	for _, formatStatus := range formats {
-		statusMessage := formatStatus.Status
-		if statusMessage == "Error" {
-			statusMessage = statusMessage + ": " + formatStatus.Description
-		}
-		formatStatusList = append(formatStatusList, statusMessage)
+		formatStatusList = append(formatStatusList, formatStatus.Status)
 	}
 	return formatStatusList
 }

--- a/provider/encodingcom/encodingcom_server_test.go
+++ b/provider/encodingcom/encodingcom_server_test.go
@@ -41,13 +41,12 @@ type fakePreset struct {
 }
 
 type fakeMedia struct {
-	ID          string
-	Request     request
-	Created     time.Time
-	Started     time.Time
-	Finished    time.Time
-	Status      string
-	Description string
+	ID       string
+	Request  request
+	Created  time.Time
+	Started  time.Time
+	Finished time.Time
+	Status   string
 }
 
 // encodingComFakeServer is a fake version of the Encoding.com API.
@@ -190,8 +189,6 @@ func (s *encodingComFakeServer) getStatus(w http.ResponseWriter, req request) {
 			"finished":   media.Finished.Format(encodingComDateFormat),
 			"output":     hlsOutput,
 			"format": map[string]interface{}{
-				"status":      status,
-				"description": media.Description,
 				"destination": []string{
 					"https://mybucket.s3.amazonaws.com/dir/job-123/some_hls_preset/video-0.m3u8",
 					"https://mybucket.s3.amazonaws.com/dir/job-123/video.m3u8",

--- a/provider/zencoder/zencoder.go
+++ b/provider/zencoder/zencoder.go
@@ -274,15 +274,10 @@ func (z *zencoderProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
 		return nil, fmt.Errorf("error getting job progress: %s", err)
 	}
 	inputMediaFile := jobDetails.Job.InputMediaFile
-	statusMessage := ""
-	if inputMediaFile.ErrorMessage != nil {
-		statusMessage = *inputMediaFile.ErrorMessage
-	}
 	return &provider.JobStatus{
 		ProviderName:  Name,
 		ProviderJobID: job.ProviderJobID,
 		Status:        z.statusMap(progress.State),
-		StatusMessage: statusMessage,
 		Progress:      progress.JobProgress,
 		Output:        jobOutputs,
 		SourceInfo: provider.SourceInfo{

--- a/provider/zencoder/zencoder_fake_test.go
+++ b/provider/zencoder/zencoder_fake_test.go
@@ -23,44 +23,6 @@ func (z *FakeZencoder) GetJobProgress(id int64) (*zencoder.JobProgress, error) {
 }
 
 func (z *FakeZencoder) GetJobDetails(id int64) (*zencoder.JobDetails, error) {
-	if id == 11111 {
-		errorMessage := "Some error happened."
-		return &zencoder.JobDetails{
-			Job: &zencoder.Job{
-				InputMediaFile: &zencoder.MediaFile{
-					Url:          "http://nyt.net/input.mov",
-					Format:       "mov",
-					VideoCodec:   "ProRes422",
-					Width:        1920,
-					Height:       1080,
-					DurationInMs: 10000,
-					ErrorMessage: &errorMessage,
-				},
-				CreatedAt:   "2016-11-05T05:02:57Z",
-				FinishedAt:  "2016-11-05T05:02:57Z",
-				UpdatedAt:   "2016-11-05T05:02:57Z",
-				SubmittedAt: "2016-11-05T05:02:57Z",
-				OutputMediaFiles: []*zencoder.MediaFile{
-					{
-						Url:          "https://mybucket.s3.amazonaws.com/destination-dir/output1.mp4",
-						Format:       "mp4",
-						VideoCodec:   "h264",
-						Width:        1920,
-						Height:       1080,
-						DurationInMs: 10000,
-					},
-					{
-						Url:          "https://mybucket.s3.amazonaws.com/destination-dir/output2.webm",
-						Format:       "webm",
-						VideoCodec:   "vp8",
-						Width:        1080,
-						Height:       720,
-						DurationInMs: 10000,
-					},
-				},
-			},
-		}, nil
-	}
 	return &zencoder.JobDetails{
 		Job: &zencoder.Job{
 			InputMediaFile: &zencoder.MediaFile{

--- a/provider/zencoder/zencoder_test.go
+++ b/provider/zencoder/zencoder_test.go
@@ -860,80 +860,62 @@ func TestZencoderJobStatus(t *testing.T) {
 		client: fakeZencoder,
 		db:     dbRepo,
 	}
-	var tests = []struct {
-		jobID         string
-		expectedError string
-	}{
-		{
-			"12345",
-			"",
-		},
-		{
-			"11111",
-			"Some error happened.",
-		},
+	jobStatus, err := prov.JobStatus(&db.Job{
+		ProviderJobID: "1234567890",
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, test := range tests {
-		jobStatus, err := prov.JobStatus(&db.Job{
-			ProviderJobID: test.jobID,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		resultJSON, err := json.Marshal(jobStatus)
-		if err != nil {
-			t.Fatal(err)
-		}
-		result := make(map[string]interface{})
-		err = json.Unmarshal(resultJSON, &result)
-		if err != nil {
-			t.Fatal(err)
-		}
-		expected := map[string]interface{}{
-			"providerName":  "zencoder",
-			"providerJobId": test.jobID,
-			"status":        "started",
-			"progress":      float64(10),
-			"sourceInfo": map[string]interface{}{
-				"duration":   float64(10000000),
-				"height":     float64(1080),
-				"width":      float64(1920),
-				"videoCodec": "ProRes422",
-			},
-			"providerStatus": map[string]interface{}{
-				"sourcefile": "http://nyt.net/input.mov",
-				"created":    "2016-11-05T05:02:57Z",
-				"finished":   "2016-11-05T05:02:57Z",
-				"updated":    "2016-11-05T05:02:57Z",
-				"started":    "2016-11-05T05:02:57Z",
-			},
-			"output": map[string]interface{}{
-				"destination": "/",
-				"files": []interface{}{
-					map[string]interface{}{
-						"path":       "s3://mybucket/destination-dir/output1.mp4",
-						"container":  "mp4",
-						"videoCodec": "h264",
-						"height":     float64(1080),
-						"width":      float64(1920),
-					},
-					map[string]interface{}{
-						"height":     float64(720),
-						"width":      float64(1080),
-						"path":       "s3://mybucket/destination-dir/output2.webm",
-						"container":  "webm",
-						"videoCodec": "vp8",
-					},
+	resultJSON, err := json.Marshal(jobStatus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := make(map[string]interface{})
+	err = json.Unmarshal(resultJSON, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := map[string]interface{}{
+		"providerName":  "zencoder",
+		"providerJobId": "1234567890",
+		"status":        "started",
+		"progress":      float64(10),
+		"sourceInfo": map[string]interface{}{
+			"duration":   float64(10000000),
+			"height":     float64(1080),
+			"width":      float64(1920),
+			"videoCodec": "ProRes422",
+		},
+		"providerStatus": map[string]interface{}{
+			"sourcefile": "http://nyt.net/input.mov",
+			"created":    "2016-11-05T05:02:57Z",
+			"finished":   "2016-11-05T05:02:57Z",
+			"updated":    "2016-11-05T05:02:57Z",
+			"started":    "2016-11-05T05:02:57Z",
+		},
+		"output": map[string]interface{}{
+			"destination": "/",
+			"files": []interface{}{
+				map[string]interface{}{
+					"path":       "s3://mybucket/destination-dir/output1.mp4",
+					"container":  "mp4",
+					"videoCodec": "h264",
+					"height":     float64(1080),
+					"width":      float64(1920),
+				},
+				map[string]interface{}{
+					"height":     float64(720),
+					"width":      float64(1080),
+					"path":       "s3://mybucket/destination-dir/output2.webm",
+					"container":  "webm",
+					"videoCodec": "vp8",
 				},
 			},
-		}
-		if test.expectedError != "" {
-			expected["statusMessage"] = test.expectedError
-		}
-		if !reflect.DeepEqual(result, expected) {
-			pretty.Fdiff(os.Stderr, expected, result)
-			t.Errorf("Wrong JobStatus returned. Want %#v. Got %#v.", expected, result)
-		}
+		},
+	}
+	if !reflect.DeepEqual(result, expected) {
+		pretty.Fdiff(os.Stderr, expected, result)
+		t.Errorf("Wrong JobStatus returned. Want %#v. Got %#v.", expected, result)
 	}
 }
 


### PR DESCRIPTION
Reverts NYTimes/video-transcoding-api#164 and re-applies it to add fix suggested by @fsouza 