### PR TITLE
Revert "encodingcom: remove dead code when creating a encoding.com Format"

### DIFF
--- a/provider/encodingcom/encodingcom.go
+++ b/provider/encodingcom/encodingcom.go
@@ -91,7 +91,8 @@ func (e *encodingComProvider) sourceMedia(original string) string {
 func (e *encodingComProvider) presetToFormat(preset db.Preset) encodingcom.Format {
 	falseYesNoBoolean := encodingcom.YesNoBoolean(false)
 	format := encodingcom.Format{
-		Output: []string{preset.Container},
+		Output:      []string{preset.Container},
+		Destination: []string{"ftp://username:password@yourftphost.com/video/encoded/test.flv"},
 	}
 	if preset.Container == "m3u8" {
 		format.Output = []string{hlsOutput}

--- a/provider/encodingcom/encodingcom_test.go
+++ b/provider/encodingcom/encodingcom_test.go
@@ -820,6 +820,7 @@ func TestCreatePreset(t *testing.T) {
 		Gop:          "cgop",
 		Keyframe:     []string{"90"},
 		Size:         "0x1080",
+		Destination:  []string{"ftp://username:password@yourftphost.com/video/encoded/test.flv"},
 	}
 	if !reflect.DeepEqual(fakePreset.Request.Format[0], expectedFormat) {
 		pretty.Fdiff(os.Stderr, fakePreset.Request.Format[0], expectedFormat)
@@ -858,8 +859,9 @@ func TestCreatePresetHLS(t *testing.T) {
 	fakePreset := server.presets[presetName]
 	falseYesNoBoolean := encodingcom.YesNoBoolean(false)
 	expectedFormat := encodingcom.Format{
-		Output:    []string{hlsOutput},
-		PackFiles: &falseYesNoBoolean,
+		Output:      []string{hlsOutput},
+		Destination: []string{"ftp://username:password@yourftphost.com/video/encoded/test.flv"},
+		PackFiles:   &falseYesNoBoolean,
 		Stream: []encodingcom.Stream{
 			{
 				AudioBitrate: "128k",
@@ -901,6 +903,7 @@ func TestPresetToFormat(t *testing.T) {
 			},
 			encodingcom.Format{
 				Output:               []string{"advanced_hls"},
+				Destination:          []string{"ftp://username:password@yourftphost.com/video/encoded/test.flv"},
 				VideoCodecParameters: encodingcom.VideoCodecParameters{},
 				Stream: []encodingcom.Stream{
 					{
@@ -928,6 +931,7 @@ func TestPresetToFormat(t *testing.T) {
 			},
 			encodingcom.Format{
 				Output:      []string{"webm"},
+				Destination: []string{"ftp://username:password@yourftphost.com/video/encoded/test.flv"},
 				AudioCodec:  "libvorbis",
 				AudioVolume: 100,
 				Gop:         "cgop",
@@ -950,6 +954,7 @@ func TestPresetToFormat(t *testing.T) {
 			},
 			encodingcom.Format{
 				Output:      []string{"webm"},
+				Destination: []string{"ftp://username:password@yourftphost.com/video/encoded/test.flv"},
 				AudioCodec:  "libvorbis",
 				AudioVolume: 100,
 				Gop:         "cgop",
@@ -974,6 +979,7 @@ func TestPresetToFormat(t *testing.T) {
 			},
 			encodingcom.Format{
 				Output:      []string{"mp4"},
+				Destination: []string{"ftp://username:password@yourftphost.com/video/encoded/test.flv"},
 				AudioCodec:  "dolby_aac",
 				AudioVolume: 100,
 				Gop:         "cgop",


### PR DESCRIPTION
Reverts NYTimes/video-transcoding-api#159 because that apparent "dead code" is needed by encoding.com to allow the creation of new presets. See #167 