### PR TITLE
zencoder: set progress to 100 when job status is finished (fixes #170)

### DIFF
--- a/provider/zencoder/zencoder.go
+++ b/provider/zencoder/zencoder.go
@@ -273,6 +273,9 @@ func (z *zencoderProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting job progress: %s", err)
 	}
+	if progress.State == "finished" {
+		progress.JobProgress = 100
+	}
 	inputMediaFile := jobDetails.Job.InputMediaFile
 	return &provider.JobStatus{
 		ProviderName:  Name,

--- a/provider/zencoder/zencoder.go
+++ b/provider/zencoder/zencoder.go
@@ -273,7 +273,7 @@ func (z *zencoderProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting job progress: %s", err)
 	}
-	if progress.State == "finished" {
+	if progress.State == zencoder.JobStateFinished {
 		progress.JobProgress = 100
 	}
 	inputMediaFile := jobDetails.Job.InputMediaFile
@@ -299,15 +299,15 @@ func (z *zencoderProvider) JobStatus(job *db.Job) (*provider.JobStatus, error) {
 	}, nil
 }
 
-func (z *zencoderProvider) statusMap(zencoderStatus string) provider.Status {
-	switch zencoderStatus {
-	case "waiting", "assigning", "pending":
+func (z *zencoderProvider) statusMap(zencoderState zencoder.JobState) provider.Status {
+	switch zencoderState {
+	case zencoder.JobStateWaiting, zencoder.JobStateAssigning, zencoder.JobStatePending:
 		return provider.StatusQueued
-	case "processing":
+	case zencoder.JobStateProcessing:
 		return provider.StatusStarted
-	case "finished":
+	case zencoder.JobStateFinished:
 		return provider.StatusFinished
-	case "cancelled":
+	case zencoder.JobStateCancelled:
 		return provider.StatusCanceled
 	default:
 		return provider.StatusFailed

--- a/provider/zencoder/zencoder_fake_test.go
+++ b/provider/zencoder/zencoder_fake_test.go
@@ -16,10 +16,10 @@ func (z *FakeZencoder) CancelJob(id int64) error {
 }
 
 func (z *FakeZencoder) GetJobProgress(id int64) (*zencoder.JobProgress, error) {
-	return &zencoder.JobProgress{
-		State:       "processing",
-		JobProgress: 10,
-	}, nil
+	if id == 1234567890 {
+		return &zencoder.JobProgress{State: "processing", JobProgress: 10}, nil
+	}
+	return &zencoder.JobProgress{State: "finished", JobProgress: 0}, nil
 }
 
 func (z *FakeZencoder) GetJobDetails(id int64) (*zencoder.JobDetails, error) {

--- a/provider/zencoder/zencoder_test.go
+++ b/provider/zencoder/zencoder_test.go
@@ -984,17 +984,16 @@ func TestZencoderStatusMap(t *testing.T) {
 		db:     dbRepo,
 	}
 	var tests = []struct {
-		Input    string
+		Input    zencoder.JobState
 		Expected provider.Status
 	}{
-		{"waiting", provider.StatusQueued},
-		{"pending", provider.StatusQueued},
-		{"assigning", provider.StatusQueued},
-		{"processing", provider.StatusStarted},
-		{"finished", provider.StatusFinished},
-		{"cancelled", provider.StatusCanceled},
-		{"failed", provider.StatusFailed},
-		{"unknown", provider.StatusFailed},
+		{zencoder.JobStateWaiting, provider.StatusQueued},
+		{zencoder.JobStatePending, provider.StatusQueued},
+		{zencoder.JobStateAssigning, provider.StatusQueued},
+		{zencoder.JobStateProcessing, provider.StatusStarted},
+		{zencoder.JobStateFinished, provider.StatusFinished},
+		{zencoder.JobStateCancelled, provider.StatusCanceled},
+		{zencoder.JobStateFailed, provider.StatusFailed},
 	}
 	for _, test := range tests {
 		if prov.statusMap(test.Input) != test.Expected {

--- a/provider/zencoder/zencoder_test.go
+++ b/provider/zencoder/zencoder_test.go
@@ -860,62 +860,111 @@ func TestZencoderJobStatus(t *testing.T) {
 		client: fakeZencoder,
 		db:     dbRepo,
 	}
-	jobStatus, err := prov.JobStatus(&db.Job{
-		ProviderJobID: "1234567890",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	resultJSON, err := json.Marshal(jobStatus)
-	if err != nil {
-		t.Fatal(err)
-	}
-	result := make(map[string]interface{})
-	err = json.Unmarshal(resultJSON, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := map[string]interface{}{
-		"providerName":  "zencoder",
-		"providerJobId": "1234567890",
-		"status":        "started",
-		"progress":      float64(10),
-		"sourceInfo": map[string]interface{}{
-			"duration":   float64(50000000000),
-			"height":     float64(1080),
-			"width":      float64(1920),
-			"videoCodec": "ProRes422",
-		},
-		"providerStatus": map[string]interface{}{
-			"sourcefile": "http://nyt.net/input.mov",
-			"created":    "2016-11-05T05:02:57Z",
-			"finished":   "2016-11-05T05:02:57Z",
-			"updated":    "2016-11-05T05:02:57Z",
-			"started":    "2016-11-05T05:02:57Z",
-		},
-		"output": map[string]interface{}{
-			"destination": "/",
-			"files": []interface{}{
-				map[string]interface{}{
-					"path":       "s3://mybucket/destination-dir/output1.mp4",
-					"container":  "mp4",
-					"videoCodec": "h264",
+	var tests = []struct {
+		ProviderJobID string
+		Expected      map[string]interface{}
+	}{
+		{
+			"1234567890",
+			map[string]interface{}{
+				"providerName":  "zencoder",
+				"providerJobId": "1234567890",
+				"status":        "started",
+				"progress":      float64(10),
+				"sourceInfo": map[string]interface{}{
+					"duration":   float64(50000000000),
 					"height":     float64(1080),
 					"width":      float64(1920),
+					"videoCodec": "ProRes422",
 				},
-				map[string]interface{}{
-					"height":     float64(720),
-					"width":      float64(1080),
-					"path":       "s3://mybucket/destination-dir/output2.webm",
-					"container":  "webm",
-					"videoCodec": "vp8",
+				"providerStatus": map[string]interface{}{
+					"sourcefile": "http://nyt.net/input.mov",
+					"created":    "2016-11-05T05:02:57Z",
+					"finished":   "2016-11-05T05:02:57Z",
+					"updated":    "2016-11-05T05:02:57Z",
+					"started":    "2016-11-05T05:02:57Z",
+				},
+				"output": map[string]interface{}{
+					"destination": "/",
+					"files": []interface{}{
+						map[string]interface{}{
+							"path":       "s3://mybucket/destination-dir/output1.mp4",
+							"container":  "mp4",
+							"videoCodec": "h264",
+							"height":     float64(1080),
+							"width":      float64(1920),
+						},
+						map[string]interface{}{
+							"height":     float64(720),
+							"width":      float64(1080),
+							"path":       "s3://mybucket/destination-dir/output2.webm",
+							"container":  "webm",
+							"videoCodec": "vp8",
+						},
+					},
+				},
+			},
+		},
+		{
+			"54321",
+			map[string]interface{}{
+				"providerName":  "zencoder",
+				"providerJobId": "54321",
+				"status":        "finished",
+				"progress":      float64(100),
+				"sourceInfo": map[string]interface{}{
+					"duration":   float64(50000000000),
+					"height":     float64(1080),
+					"width":      float64(1920),
+					"videoCodec": "ProRes422",
+				},
+				"providerStatus": map[string]interface{}{
+					"sourcefile": "http://nyt.net/input.mov",
+					"created":    "2016-11-05T05:02:57Z",
+					"finished":   "2016-11-05T05:02:57Z",
+					"updated":    "2016-11-05T05:02:57Z",
+					"started":    "2016-11-05T05:02:57Z",
+				},
+				"output": map[string]interface{}{
+					"destination": "/",
+					"files": []interface{}{
+						map[string]interface{}{
+							"path":       "s3://mybucket/destination-dir/output1.mp4",
+							"container":  "mp4",
+							"videoCodec": "h264",
+							"height":     float64(1080),
+							"width":      float64(1920),
+						},
+						map[string]interface{}{
+							"height":     float64(720),
+							"width":      float64(1080),
+							"path":       "s3://mybucket/destination-dir/output2.webm",
+							"container":  "webm",
+							"videoCodec": "vp8",
+						},
+					},
 				},
 			},
 		},
 	}
-	if !reflect.DeepEqual(result, expected) {
-		pretty.Fdiff(os.Stderr, expected, result)
-		t.Errorf("Wrong JobStatus returned. Want %#v. Got %#v.", expected, result)
+	for _, test := range tests {
+		jobStatus, err := prov.JobStatus(&db.Job{ProviderJobID: test.ProviderJobID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		resultJSON, err := json.Marshal(jobStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := make(map[string]interface{})
+		err = json.Unmarshal(resultJSON, &result)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(result, test.Expected) {
+			pretty.Fdiff(os.Stderr, test.Expected, result)
+			t.Errorf("Wrong JobStatus returned. Want %#v. Got %#v.", test.Expected, result)
+		}
 	}
 }
 


### PR DESCRIPTION
⚠️ for @marzagao, @fsouza and @scentless-apprentice, I updated our https://github.com/flavioribeiro/zencoder/commit/85fa27b689187b9fffc1c73c594a45ae9e77869d fork so you'll need to update yours in order to run the API if this PR get merged