### PR TITLE
bitmovin:encodes audio only when a track is available

### DIFF
--- a/provider/bitmovin/bitmovin.go
+++ b/provider/bitmovin/bitmovin.go
@@ -629,6 +629,7 @@ func (p *bitmovinProvider) Transcode(job *db.Job) (*provider.JobStatus, error) {
 			audioStream := &models.Stream{
 				CodecConfigurationID: &audioPresetID,
 				InputStreams:         aiss,
+				Conditions:           models.NewAttributeCondition(bitmovintypes.ConditionAttributeInputStream, "==", "true"),
 			}
 			audioStreamResp, audioErr := encodingS.AddStream(*encodingResp.Data.Result.ID, audioStream)
 			if audioErr != nil {


### PR DESCRIPTION
Ticket: https://jira.nyt.net/browse/MULT-456
Proof it works: https://dashboard.bitmovin.com/encoding/encodings/5440df77-c306-4480-87e6-f157e25bf966

