### PR TITLE
testing: bugfix addressing data race when testing job creation

### DIFF
--- a/db/redis/job_test.go
+++ b/db/redis/job_test.go
@@ -94,15 +94,15 @@ func TestCreateJobIsSafe(t *testing.T) {
 		t.Fatal(err)
 	}
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for i := 0; i < len(jobs); i++ {
 		wg.Add(1)
-		go func(i int) {
+		go func(job db.Job) {
 			defer wg.Done()
-			err := repo.CreateJob(&jobs[i])
+			err := repo.CreateJob(&job)
 			if err != nil && err != redis.TxFailedErr {
 				t.Error(err)
 			}
-		}(i % len(jobs))
+		}(jobs[i])
 	}
 	wg.Wait()
 }

--- a/db/redis/job_test.go
+++ b/db/redis/job_test.go
@@ -94,7 +94,7 @@ func TestCreateJobIsSafe(t *testing.T) {
 		t.Fatal(err)
 	}
 	var wg sync.WaitGroup
-	for i := 0; i < len(jobs); i++ {
+	for i := 0; i < len(jobs)*2; i++ {
 		wg.Add(1)
 		go func(job db.Job) {
 			defer wg.Done()
@@ -102,7 +102,7 @@ func TestCreateJobIsSafe(t *testing.T) {
 			if err != nil && err != redis.TxFailedErr {
 				t.Error(err)
 			}
-		}(jobs[i])
+		}(jobs[i % len(jobs)])
 	}
 	wg.Wait()
 }

--- a/db/redis/job_test.go
+++ b/db/redis/job_test.go
@@ -102,7 +102,7 @@ func TestCreateJobIsSafe(t *testing.T) {
 			if err != nil && err != redis.TxFailedErr {
 				t.Error(err)
 			}
-		}(jobs[i % len(jobs)])
+		}(jobs[i%len(jobs)])
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
I'm new to this repository and testing out the features currently implemented. After a clone, I noticed that while `go test ./...` was passing, when adding the `-race` param, you encounter the following race:

```
==================
WARNING: DATA RACE
Write at 0x00c00001f620 by goroutine 33:
  github.com/NYTimes/video-transcoding-api/db/redis.(*redisRepository).CreateJob()
      /Users/Symborski/dev/video-transcoding-api/db/redis/job.go:19 +0x1ad
  github.com/NYTimes/video-transcoding-api/db/redis.TestCreateJobIsSafe.func1()
      /Users/Symborski/dev/video-transcoding-api/db/redis/job_test.go:101 +0x96

Previous write at 0x00c00001f620 by goroutine 25:
  github.com/NYTimes/video-transcoding-api/db/redis.(*redisRepository).CreateJob()
      /Users/Symborski/dev/video-transcoding-api/db/redis/job.go:19 +0x1ad
  github.com/NYTimes/video-transcoding-api/db/redis.TestCreateJobIsSafe.func1()
      /Users/Symborski/dev/video-transcoding-api/db/redis/job_test.go:101 +0x96

Goroutine 33 (running) created at:
  github.com/NYTimes/video-transcoding-api/db/redis.TestCreateJobIsSafe()
      /Users/Symborski/dev/video-transcoding-api/db/redis/job_test.go:99 +0x3b9
  testing.tRunner()
      /usr/local/Cellar/go/1.11.5/libexec/src/testing/testing.go:827 +0x162

Goroutine 25 (running) created at:
  github.com/NYTimes/video-transcoding-api/db/redis.TestCreateJobIsSafe()
      /Users/Symborski/dev/video-transcoding-api/db/redis/job_test.go:99 +0x3b9
  testing.tRunner()
      /usr/local/Cellar/go/1.11.5/libexec/src/testing/testing.go:827 +0x162
==================
``` 

I made a quick change to address this issue.

```
~/dev/video-transcoding-api ➤ c79d88c|bug-test-datarace⚡ ± go test ./... -race
?   	github.com/NYTimes/video-transcoding-api	[no test files]
ok  	github.com/NYTimes/video-transcoding-api/config	(cached)
ok  	github.com/NYTimes/video-transcoding-api/db	(cached)
ok  	github.com/NYTimes/video-transcoding-api/db/dbtest	(cached)
ok  	github.com/NYTimes/video-transcoding-api/db/redis	(cached)
ok  	github.com/NYTimes/video-transcoding-api/db/redis/storage	1.073s
ok  	github.com/NYTimes/video-transcoding-api/provider	(cached)
ok  	github.com/NYTimes/video-transcoding-api/provider/bitmovin	(cached)
ok  	github.com/NYTimes/video-transcoding-api/provider/elastictranscoder	(cached)
ok  	github.com/NYTimes/video-transcoding-api/provider/elementalconductor	(cached)
ok  	github.com/NYTimes/video-transcoding-api/provider/encodingcom	(cached)
?   	github.com/NYTimes/video-transcoding-api/provider/hybrik	[no test files]
ok  	github.com/NYTimes/video-transcoding-api/provider/zencoder	(cached)
ok  	github.com/NYTimes/video-transcoding-api/service	(cached)
ok  	github.com/NYTimes/video-transcoding-api/swagger	(cached)
```

While I'm not 100% sure what the true purpose `TestCreateJobIsSafe()` is, the race may constitute a failure, but I'd look to the author or maintainers for guidance.